### PR TITLE
Re-Export setCustomElements

### DIFF
--- a/src/web-components.js
+++ b/src/web-components.js
@@ -7,6 +7,7 @@ export { React, registerPreviewEntry, mdx };
 export {
   storiesOf,
   setAddon,
+  setCustomElements,
   addDecorator,
   addParameters,
   configure,


### PR DESCRIPTION
Currently, setCustomElements is not reexported in the web-components.js file so when you go do:

`import { setCustomElements } from "@web/storybook-prebuilt/web-components.js"`

You receive an error.

Here is the Storybook equivalent:

https://github.com/storybookjs/storybook/blob/next/examples/web-components-kitchen-sink/.storybook/preview.js

Perhaps this could be changed to `export * from "@storybook/web-components"` in case this API changes in the future?