### PR TITLE
fix: include addArgsEnhancer when processing preview entries

### DIFF
--- a/demo/wc/stories/Button.stories.js
+++ b/demo/wc/stories/Button.stories.js
@@ -6,6 +6,11 @@ export default {
     backgroundColor: { control: 'color' },
     onClick: { action: 'onClick' },
   },
+  parameters: {
+    actions: {
+      handles: [ 'click' ]
+    }
+  }
 };
 
 const Template = args => Button(args);

--- a/src/registerPreviewEntry.js
+++ b/src/registerPreviewEntry.js
@@ -1,12 +1,15 @@
-import { addDecorator, addParameters, addArgTypesEnhancer } from '@storybook/client-api';
+import { addDecorator, addParameters, addArgsEnhancer, addArgTypesEnhancer } from '@storybook/client-api';
 
 export function registerPreviewEntry(entry) {
-  const { decorators, parameters, argTypesEnhancers, globals, globalTypes } = entry;
+  const { decorators, parameters, argsEnhancers, argTypesEnhancers, globals, globalTypes } = entry;
   if (decorators) {
     decorators.forEach(decorator => addDecorator(decorator, false));
   }
   if (parameters || globals || globalTypes) {
     addParameters({ ...parameters, globals, globalTypes }, false);
+  }
+  if (argsEnhancers) {
+    argsEnhancers.forEach(enhancer => addArgsEnhancer(enhancer));
   }
   if (argTypesEnhancers) {
     argTypesEnhancers.forEach(enhancer => addArgTypesEnhancer(enhancer));


### PR DESCRIPTION
- use `addArgsEnhancer` in `registerPreviewEntry` to ensure we've appropriately consumed all addons.

WC demo will now announce both `onClick` the synthetic function and `click` the listener in the `Actions` tab of the Storybook UI.