### PR TITLE
fix: require React locally to override peerdependency resolutions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,8 @@
         "lit-html": "2.0.2",
         "magic-string": "0.25.7",
         "preact": "10.6.4",
+        "react": "16.14.0",
+        "react-dom": "16.14.0",
         "rollup": "2.61.1",
         "rollup-plugin-node-builtins": "2.1.2",
         "rollup-plugin-node-globals": "1.4.0",
@@ -3273,9 +3275,9 @@
       }
     },
     "node_modules/@storybook/builder-webpack4/node_modules/@types/node": {
-      "version": "14.18.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.1.tgz",
-      "integrity": "sha512-fTFWOFrgAkj737w1o0HLTIgisgYHnsZfeiqhG1Ltrf/iJjudEbUwetQAsfrtVE49JGwvpEzQR+EbMkIqG4227g==",
+      "version": "14.18.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.3.tgz",
+      "integrity": "sha512-GtTH2crF4MtOIrrAa+jgTV9JX/PfoUCYr6MiZw7O/dkZu5b6gm5dc1nAL0jwGo4ortSBBtGyeVaxdC8X6V+pLg==",
       "dev": true
     },
     "node_modules/@storybook/builder-webpack4/node_modules/babel-plugin-polyfill-corejs3": {
@@ -3592,9 +3594,9 @@
       }
     },
     "node_modules/@storybook/core-common/node_modules/@types/node": {
-      "version": "14.18.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.1.tgz",
-      "integrity": "sha512-fTFWOFrgAkj737w1o0HLTIgisgYHnsZfeiqhG1Ltrf/iJjudEbUwetQAsfrtVE49JGwvpEzQR+EbMkIqG4227g==",
+      "version": "14.18.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.3.tgz",
+      "integrity": "sha512-GtTH2crF4MtOIrrAa+jgTV9JX/PfoUCYr6MiZw7O/dkZu5b6gm5dc1nAL0jwGo4ortSBBtGyeVaxdC8X6V+pLg==",
       "dev": true
     },
     "node_modules/@storybook/core-common/node_modules/ansi-styles": {
@@ -3850,9 +3852,9 @@
       }
     },
     "node_modules/@storybook/core-server/node_modules/@types/node": {
-      "version": "14.18.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.1.tgz",
-      "integrity": "sha512-fTFWOFrgAkj737w1o0HLTIgisgYHnsZfeiqhG1Ltrf/iJjudEbUwetQAsfrtVE49JGwvpEzQR+EbMkIqG4227g==",
+      "version": "14.18.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.3.tgz",
+      "integrity": "sha512-GtTH2crF4MtOIrrAa+jgTV9JX/PfoUCYr6MiZw7O/dkZu5b6gm5dc1nAL0jwGo4ortSBBtGyeVaxdC8X6V+pLg==",
       "dev": true
     },
     "node_modules/@storybook/core-server/node_modules/ansi-styles": {
@@ -4003,9 +4005,9 @@
       }
     },
     "node_modules/@storybook/manager-webpack4/node_modules/@types/node": {
-      "version": "14.18.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.1.tgz",
-      "integrity": "sha512-fTFWOFrgAkj737w1o0HLTIgisgYHnsZfeiqhG1Ltrf/iJjudEbUwetQAsfrtVE49JGwvpEzQR+EbMkIqG4227g==",
+      "version": "14.18.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.3.tgz",
+      "integrity": "sha512-GtTH2crF4MtOIrrAa+jgTV9JX/PfoUCYr6MiZw7O/dkZu5b6gm5dc1nAL0jwGo4ortSBBtGyeVaxdC8X6V+pLg==",
       "dev": true
     },
     "node_modules/@storybook/manager-webpack4/node_modules/ansi-styles": {
@@ -4179,45 +4181,6 @@
         "@babel/core": "*",
         "preact": "^8.0.0||^10.0.0",
         "webpack": "*"
-      }
-    },
-    "node_modules/@storybook/preact/node_modules/react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-      "dev": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@storybook/preact/node_modules/react-dom": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-      "dev": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.19.1"
-      },
-      "peerDependencies": {
-        "react": "^16.14.0"
-      }
-    },
-    "node_modules/@storybook/preact/node_modules/scheduler": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-      "dev": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
       }
     },
     "node_modules/@storybook/preview-web": {
@@ -4518,45 +4481,6 @@
         "lit-html": "^1.4.1 || ^2.0.0"
       }
     },
-    "node_modules/@storybook/web-components/node_modules/react": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-      "dev": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@storybook/web-components/node_modules/react-dom": {
-      "version": "16.14.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-      "dev": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.19.1"
-      },
-      "peerDependencies": {
-        "react": "^16.14.0"
-      }
-    },
-    "node_modules/@storybook/web-components/node_modules/scheduler": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-      "dev": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
-    },
     "node_modules/@types/accepts": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.5.tgz",
@@ -4706,9 +4630,9 @@
       "dev": true
     },
     "node_modules/@types/istanbul-lib-coverage": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
-      "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
+      "integrity": "sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==",
       "dev": true
     },
     "node_modules/@types/istanbul-lib-report": {
@@ -4864,9 +4788,9 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "17.0.37",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.37.tgz",
-      "integrity": "sha512-2FS1oTqBGcH/s0E+CjrCCR9+JMpsu9b69RTFO+40ua43ZqP5MmQ4iUde/dMjWR909KxZwmOQIFq6AV6NjEG5xg==",
+      "version": "17.0.38",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.38.tgz",
+      "integrity": "sha512-SI92X1IA+FMnP3qM5m4QReluXzhcmovhZnLNm3pyeQlooi02qI7sLiepEYqT678uNiyc25XfCqxREFpy3W7YhQ==",
       "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
@@ -8209,9 +8133,9 @@
       }
     },
     "node_modules/core-js-pure": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.20.0.tgz",
-      "integrity": "sha512-qsrbIwWSEEYOM7z616jAVgwhuDDtPLwZSpUsU3vyUkHYqKTf/uwOJBZg2V7lMurYWkpVlaVOxBrfX0Q3ppvjfg==",
+      "version": "3.20.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.20.1.tgz",
+      "integrity": "sha512-yeNNr3L9cEBwNy6vhhIJ0nko7fE7uFO6PgawcacGt2VWep4WqQx0RiqlkgSP7kqUMC1IKdfO9qPeWXcUheHLVQ==",
       "dev": true,
       "hasInstallScript": true,
       "funding": {
@@ -9614,9 +9538,9 @@
       }
     },
     "node_modules/es5-shim": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.6.2.tgz",
-      "integrity": "sha512-n0XTVMGps+Deyr38jtqKPR5F5hb9owYeRQcKJW39eFvzUk/u/9Ww315werRzbiNMnHCUw/YHDPBphTlEnzdi+A==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.6.4.tgz",
+      "integrity": "sha512-Z0f7OUYZ8JfqT12d3Tgh2ErxIH5Shaz97GE8qyDG9quxb2Hmh2vvFHlOFjx6lzyD0CRgvJfnNYcisjdbRp7MPw==",
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
@@ -16222,14 +16146,14 @@
       }
     },
     "node_modules/react": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2"
       },
       "engines": {
         "node": ">=0.10.0"
@@ -16454,18 +16378,18 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
-      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
-        "scheduler": "^0.20.2"
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.19.1"
       },
       "peerDependencies": {
-        "react": "17.0.2"
+        "react": "^16.14.0"
       }
     },
     "node_modules/react-draggable": {
@@ -17769,11 +17693,10 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -19474,12 +19397,6 @@
         "node": ">=6.10"
       }
     },
-    "node_modules/ts-essentials": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-2.0.12.tgz",
-      "integrity": "sha512-3IVX4nI6B5cc31/GFFE+i8ey/N2eA0CZDbo6n0yrz0zDX8ZJ8djmU1p+XRz7G3is0F3bB3pu2pAroFdAWQKU3w==",
-      "dev": true
-    },
     "node_modules/ts-pnp": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.2.0.tgz",
@@ -20021,13 +19938,10 @@
       }
     },
     "node_modules/use-composed-ref": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.1.0.tgz",
-      "integrity": "sha512-my1lNHGWsSDAhhVAT4MKs6IjBUtG6ZG11uUqexPH9PptiIZDQOzaF4f5tEbJ2+7qvNbtXNBbU3SfmN+fXlWDhg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.2.1.tgz",
+      "integrity": "sha512-6+X1FLlIcjvFMAeAD/hcxDT8tmyrWnbSPMU0EnxQuDLIxokuFzWliXBiYZuGIx+mrAMLBw0WFfCkaPw8ebzAhw==",
       "dev": true,
-      "dependencies": {
-        "ts-essentials": "^2.0.3"
-      },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0"
       }
@@ -21212,9 +21126,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.3.0.tgz",
-      "integrity": "sha512-Gs5EZtpqZzLvmIM59w4igITU57lrtYVFneaa434VROv4thzJyV6UjIL3D42lslWlI+D4KzLYnxSwtfuiO79sNw==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.0.tgz",
+      "integrity": "sha512-IHVsKe2pjajSUIl4KYMQOdlyliovpEPquKkqbwswulszzI7r0SfQrxnXdWAEqOlDCLrVSJzo+O1hAwdog2sKSQ==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
@@ -23558,9 +23472,9 @@
           }
         },
         "@types/node": {
-          "version": "14.18.1",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.1.tgz",
-          "integrity": "sha512-fTFWOFrgAkj737w1o0HLTIgisgYHnsZfeiqhG1Ltrf/iJjudEbUwetQAsfrtVE49JGwvpEzQR+EbMkIqG4227g==",
+          "version": "14.18.3",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.3.tgz",
+          "integrity": "sha512-GtTH2crF4MtOIrrAa+jgTV9JX/PfoUCYr6MiZw7O/dkZu5b6gm5dc1nAL0jwGo4ortSBBtGyeVaxdC8X6V+pLg==",
           "dev": true
         },
         "babel-plugin-polyfill-corejs3": {
@@ -23796,9 +23710,9 @@
           }
         },
         "@types/node": {
-          "version": "14.18.1",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.1.tgz",
-          "integrity": "sha512-fTFWOFrgAkj737w1o0HLTIgisgYHnsZfeiqhG1Ltrf/iJjudEbUwetQAsfrtVE49JGwvpEzQR+EbMkIqG4227g==",
+          "version": "14.18.3",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.3.tgz",
+          "integrity": "sha512-GtTH2crF4MtOIrrAa+jgTV9JX/PfoUCYr6MiZw7O/dkZu5b6gm5dc1nAL0jwGo4ortSBBtGyeVaxdC8X6V+pLg==",
           "dev": true
         },
         "ansi-styles": {
@@ -23976,9 +23890,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.18.1",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.1.tgz",
-          "integrity": "sha512-fTFWOFrgAkj737w1o0HLTIgisgYHnsZfeiqhG1Ltrf/iJjudEbUwetQAsfrtVE49JGwvpEzQR+EbMkIqG4227g==",
+          "version": "14.18.3",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.3.tgz",
+          "integrity": "sha512-GtTH2crF4MtOIrrAa+jgTV9JX/PfoUCYr6MiZw7O/dkZu5b6gm5dc1nAL0jwGo4ortSBBtGyeVaxdC8X6V+pLg==",
           "dev": true
         },
         "ansi-styles": {
@@ -24096,9 +24010,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.18.1",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.1.tgz",
-          "integrity": "sha512-fTFWOFrgAkj737w1o0HLTIgisgYHnsZfeiqhG1Ltrf/iJjudEbUwetQAsfrtVE49JGwvpEzQR+EbMkIqG4227g==",
+          "version": "14.18.3",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.3.tgz",
+          "integrity": "sha512-GtTH2crF4MtOIrrAa+jgTV9JX/PfoUCYr6MiZw7O/dkZu5b6gm5dc1nAL0jwGo4ortSBBtGyeVaxdC8X6V+pLg==",
           "dev": true
         },
         "ansi-styles": {
@@ -24215,41 +24129,6 @@
         "read-pkg-up": "^7.0.1",
         "regenerator-runtime": "^0.13.7",
         "ts-dedent": "^2.0.0"
-      },
-      "dependencies": {
-        "react": {
-          "version": "16.14.0",
-          "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-          "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "react-dom": {
-          "version": "16.14.0",
-          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-          "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "scheduler": "^0.19.1"
-          }
-        },
-        "scheduler": {
-          "version": "0.19.1",
-          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-          "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1"
-          }
-        }
       }
     },
     "@storybook/preview-web": {
@@ -24466,41 +24345,6 @@
         "read-pkg-up": "^7.0.1",
         "regenerator-runtime": "^0.13.7",
         "ts-dedent": "^2.0.0"
-      },
-      "dependencies": {
-        "react": {
-          "version": "16.14.0",
-          "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
-          "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2"
-          }
-        },
-        "react-dom": {
-          "version": "16.14.0",
-          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
-          "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2",
-            "scheduler": "^0.19.1"
-          }
-        },
-        "scheduler": {
-          "version": "0.19.1",
-          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
-          "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1"
-          }
-        }
       }
     },
     "@types/accepts": {
@@ -24652,9 +24496,9 @@
       "dev": true
     },
     "@types/istanbul-lib-coverage": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
-      "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
+      "integrity": "sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==",
       "dev": true
     },
     "@types/istanbul-lib-report": {
@@ -24810,9 +24654,9 @@
       "dev": true
     },
     "@types/react": {
-      "version": "17.0.37",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.37.tgz",
-      "integrity": "sha512-2FS1oTqBGcH/s0E+CjrCCR9+JMpsu9b69RTFO+40ua43ZqP5MmQ4iUde/dMjWR909KxZwmOQIFq6AV6NjEG5xg==",
+      "version": "17.0.38",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.38.tgz",
+      "integrity": "sha512-SI92X1IA+FMnP3qM5m4QReluXzhcmovhZnLNm3pyeQlooi02qI7sLiepEYqT678uNiyc25XfCqxREFpy3W7YhQ==",
       "dev": true,
       "requires": {
         "@types/prop-types": "*",
@@ -27525,9 +27369,9 @@
       }
     },
     "core-js-pure": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.20.0.tgz",
-      "integrity": "sha512-qsrbIwWSEEYOM7z616jAVgwhuDDtPLwZSpUsU3vyUkHYqKTf/uwOJBZg2V7lMurYWkpVlaVOxBrfX0Q3ppvjfg==",
+      "version": "3.20.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.20.1.tgz",
+      "integrity": "sha512-yeNNr3L9cEBwNy6vhhIJ0nko7fE7uFO6PgawcacGt2VWep4WqQx0RiqlkgSP7kqUMC1IKdfO9qPeWXcUheHLVQ==",
       "dev": true
     },
     "core-util-is": {
@@ -28678,9 +28522,9 @@
       }
     },
     "es5-shim": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.6.2.tgz",
-      "integrity": "sha512-n0XTVMGps+Deyr38jtqKPR5F5hb9owYeRQcKJW39eFvzUk/u/9Ww315werRzbiNMnHCUw/YHDPBphTlEnzdi+A==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.6.4.tgz",
+      "integrity": "sha512-Z0f7OUYZ8JfqT12d3Tgh2ErxIH5Shaz97GE8qyDG9quxb2Hmh2vvFHlOFjx6lzyD0CRgvJfnNYcisjdbRp7MPw==",
       "dev": true
     },
     "es6-shim": {
@@ -33925,14 +33769,14 @@
       }
     },
     "react": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
+      "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
       "dev": true,
-      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2"
       }
     },
     "react-colorful": {
@@ -34101,15 +33945,15 @@
       }
     },
     "react-dom": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
-      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "version": "16.14.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.14.0.tgz",
+      "integrity": "sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==",
       "dev": true,
-      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
-        "scheduler": "^0.20.2"
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.19.1"
       }
     },
     "react-draggable": {
@@ -35143,11 +34987,10 @@
       }
     },
     "scheduler": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
       "dev": true,
-      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -36526,12 +36369,6 @@
       "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
       "dev": true
     },
-    "ts-essentials": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/ts-essentials/-/ts-essentials-2.0.12.tgz",
-      "integrity": "sha512-3IVX4nI6B5cc31/GFFE+i8ey/N2eA0CZDbo6n0yrz0zDX8ZJ8djmU1p+XRz7G3is0F3bB3pu2pAroFdAWQKU3w==",
-      "dev": true
-    },
     "ts-pnp": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.2.0.tgz",
@@ -36929,13 +36766,11 @@
       "dev": true
     },
     "use-composed-ref": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.1.0.tgz",
-      "integrity": "sha512-my1lNHGWsSDAhhVAT4MKs6IjBUtG6ZG11uUqexPH9PptiIZDQOzaF4f5tEbJ2+7qvNbtXNBbU3SfmN+fXlWDhg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.2.1.tgz",
+      "integrity": "sha512-6+X1FLlIcjvFMAeAD/hcxDT8tmyrWnbSPMU0EnxQuDLIxokuFzWliXBiYZuGIx+mrAMLBw0WFfCkaPw8ebzAhw==",
       "dev": true,
-      "requires": {
-        "ts-essentials": "^2.0.3"
-      }
+      "requires": {}
     },
     "use-isomorphic-layout-effect": {
       "version": "1.1.1",
@@ -37915,9 +37750,9 @@
       }
     },
     "ws": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.3.0.tgz",
-      "integrity": "sha512-Gs5EZtpqZzLvmIM59w4igITU57lrtYVFneaa434VROv4thzJyV6UjIL3D42lslWlI+D4KzLYnxSwtfuiO79sNw==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.4.0.tgz",
+      "integrity": "sha512-IHVsKe2pjajSUIl4KYMQOdlyliovpEPquKkqbwswulszzI7r0SfQrxnXdWAEqOlDCLrVSJzo+O1hAwdog2sKSQ==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -57,6 +57,8 @@
     "lit-html": "2.0.2",
     "magic-string": "0.25.7",
     "preact": "10.6.4",
+    "react": "16.14.0",
+    "react-dom": "16.14.0",
     "rollup": "2.61.1",
     "rollup-plugin-node-builtins": "2.1.2",
     "rollup-plugin-node-globals": "1.4.0",


### PR DESCRIPTION
fixes #105 

I've run an alpha as `@web/storybook-prebuilt@0.1.32-alpha.0` so maybe @abdonrd could get me a second on this fixing things.

Locally the preview now run again in the repo, so this should do the trick. It looks like the peer dependency on React at a higher level in some dependencies that in Storybook was buggering the version resolution and leaving it out of `node_modules` and thus out of the build. Installing locally is not my favorite fix, but I'm not sure what we can do while Storybook remains on `v16`...

Thoughts?